### PR TITLE
test: Use MiniWallet  in mempool_limit.py

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -25,6 +25,7 @@ class MempoolLimitTest(BitcoinTestFramework):
 
     def run_test(self):
         txouts = gen_return_txouts()
+        # Helper function that generates large transactions
 
         node = self.nodes[0]
         miniwallet = MiniWallet(node)
@@ -34,40 +35,63 @@ class MempoolLimitTest(BitcoinTestFramework):
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
-        txids=[]
-        miniwallet.generate(92)
-        node.generate(COINBASE_MATURITY+1)
+        tx_ids=[]
+        miniwallet.generate(1 + (3*30) + 1)
+        # We generate 92 Coinbase UTXOs here because we need
+        # 1 to create a tx that will be evicted from the mempool later
+        # 30 with a fee higher than the previous UTXO
+        # Another 30 with a fee higher than the previous set of UTXOs
+        # Another 30 with a fee even higher than  the previous set of UTXOs
+        # And 1 more to verify that this tx does not get added to the mempool with a relayfee (fee less than the mempoolminfee)
+
+        node.generate(COINBASE_MATURITY - 1)
+        # We mine 99 blocks so that we are allowed to spend our UTXOs
+        
 
         self.log.info('Create a mempool tx that will be evicted')
-        tx_to_be_evicted_id = miniwallet.send_self_transfer(fee_rate = relayfee, from_node = node)['txid']
+        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node = node, fee_rate = relayfee)['txid']
 
         base_fee = relayfee*1000
-        for i in range (3):
-            txids.append([])
-            txids[i] = self.create_large_transactions(node, txouts, miniwallet, 30, (i+1)*base_fee)
+        # We increase the tx fee massively now to give these transactions a higher priority in the mempool
+
+        for batch_of_txid in range (3):
+            tx_ids.append([])
+            tx_ids[batch_of_txid] = self.create_large_transactions(node, txouts, miniwallet, 30, (batch_of_txid+1)*base_fee)
+            # We gradually increase the tx fee by incrementing it by a factor of (basee_fee) for each batch of 30 transactions
 
         self.log.info('The tx should be evicted by now')
-        assert_greater_than(len([txid for batch in txids for txid in batch]), len(node.getrawmempool()))
-        assert tx_to_be_evicted_id not in node.getrawmempool() # check txid in the raw mempool
+        assert_greater_than(len([txid for batch in tx_ids for txid in batch]), len(node.getrawmempool()))
+        # We assert that the number of created transactions is greater than the ones in the mempool
+        assert tx_to_be_evicted_id not in node.getrawmempool() 
+        # We assert that our initial tx_to_be_evicted_id is not present in the mempool anymore as it's fee was less
 
         self.log.info('Check that mempoolminfee is larger than minrelytxfee')
         assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
         assert_greater_than(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
+        # We deliberately create a tx with a fee less that the minimum mempool fee to assert that it does not get added to the mempool
         assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee,mempool_valid=False)
 
-    def create_large_transactions(self, node, txouts, miniwallet, num, fee):
+    def create_large_transactions(self, node, array_of_large_tx, miniwallet, no_of_tx_ids, fee_rate):
+    # This helper function is used to create large transactions by splicing in "txouts"
         large_txids = []
-        for _ in range(num):
-            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=fee)
+        for _ in range(no_of_tx_ids):
+        # Loop that gives us a list of size num of large transaction IDs 
+            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=fee_rate)
+            # We create a self transfer here and get the tx details
             hex=tx['hex']
             tx_instance = from_hex(CTransaction(), hex)
-            for txout in txouts:
+            # We convert it into a CTransaction() instance
+            for txout in array_of_large_tx:
                 tx_instance.vout.append(txout)
+            # We append the tx outs that we received from the gen_return_txouts() to our tx instance to increase the tx size
             tx_hex = tx_instance.serialize().hex()
             miniwallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=tx_hex)
+            # We now serialisze it and send the tx to the nodes
+
             large_txids.append(tx['txid'])
+            # We now append this tx ID to our array of large tx IDs
         return large_txids
 
 if __name__ == '__main__':

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -8,91 +8,87 @@ from decimal import Decimal
 from test_framework.blocktools import COINBASE_MATURITY
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, gen_return_txouts
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_rpc_error,
+    gen_return_txouts,
+)
 from test_framework.wallet import MiniWallet
-from test_framework.messages import CTransaction, from_hex
+
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [[
-            "-acceptnonstdtxn=1",
-            "-maxmempool=5",
-            "-spendzeroconfchange=0",
-        ]]
+        self.extra_args = [
+            [
+                "-acceptnonstdtxn=1",
+                "-maxmempool=5",
+                "-spendzeroconfchange=0",
+            ]
+        ]
         self.supports_cli = False
 
     def run_test(self):
         txouts = gen_return_txouts()
-        # Helper function that generates large transactions
 
         node = self.nodes[0]
         miniwallet = MiniWallet(node)
-        relayfee = node.getnetworkinfo()['relayfee']
+        relayfee = node.getnetworkinfo()["relayfee"]
 
-        self.log.info('Check that mempoolminfee is minrelytxfee')
-        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        self.log.info("Check that mempoolminfee is minrelaytxfee")
+        assert_equal(node.getmempoolinfo()["minrelaytxfee"], Decimal("0.00001000"))
+        assert_equal(node.getmempoolinfo()["mempoolminfee"], Decimal("0.00001000"))
 
-        tx_ids=[]
-        miniwallet.generate(1 + (3*30) + 1)
-        # We generate 92 Coinbase UTXOs here because we need
-        # 1 to create a tx that will be evicted from the mempool later
-        # 30 with a fee higher than the previous UTXO
-        # Another 30 with a fee higher than the previous set of UTXOs
-        # Another 30 with a fee even higher than  the previous set of UTXOs
-        # And 1 more to verify that this tx does not get added to the mempool with a relayfee (fee less than the mempoolminfee)
+        # Generate 92 UTXOs to flood the mempool
+        # 1 to create a tx initially that will be evicted from the mempool later
+        # 90 with a fee rate much higher than the previous UTXO (3 batches of 30 with increasing fee rate)
+        # And 1 more to verify that this tx does not get added to the mempool with a fee rate less than the mempoolminfee
+        miniwallet.generate(1 + (3 * 30) + 1)
 
+        # Mine 99 blocks so that the UTXOs are allowed to be spent
         node.generate(COINBASE_MATURITY - 1)
-        # We mine 99 blocks so that we are allowed to spend our UTXOs
-        
 
-        self.log.info('Create a mempool tx that will be evicted')
-        tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node = node, fee_rate = relayfee)['txid']
+        self.log.info("Create a mempool tx that will be evicted")
+        tx_to_be_evicted_id = miniwallet.send_self_transfer(
+            from_node=node, fee_rate=relayfee
+        )["txid"]
 
-        base_fee = relayfee*1000
-        # We increase the tx fee massively now to give these transactions a higher priority in the mempool
+        # Increase the tx fee rate massively now to give the next transactions a higher priority in the mempool
+        base_fee = relayfee * 1000
 
-        for batch_of_txid in range (3):
-            tx_ids.append([])
-            tx_ids[batch_of_txid] = self.create_large_transactions(node, txouts, miniwallet, 30, (batch_of_txid+1)*base_fee)
-            # We gradually increase the tx fee by incrementing it by a factor of (basee_fee) for each batch of 30 transactions
+        self.log.info("Fill up the mempool with txs with higher fee rate")
+        no_of_large_tx_created = 0
+        for batch_of_txid in range(3):
+            # Increment the tx fee rate gradually by a factor of (basee_fee) for each batch of 30 transactions
+            no_of_large_tx_created += miniwallet.create_large_transactions(
+                node, txouts, 30, (batch_of_txid + 1) * base_fee
+            )
 
-        self.log.info('The tx should be evicted by now')
-        assert_greater_than(len([txid for batch in tx_ids for txid in batch]), len(node.getrawmempool()))
-        # We assert that the number of created transactions is greater than the ones in the mempool
-        assert tx_to_be_evicted_id not in node.getrawmempool() 
-        # We assert that our initial tx_to_be_evicted_id is not present in the mempool anymore as it's fee was less
+        self.log.info("The tx should be evicted by now")
+        # The number of transactions created should be greater than the ones present in the mempool
+        assert_greater_than(no_of_large_tx_created, len(node.getrawmempool()))
+        # Initial tx created should not be present in the mempool anymore as it had a lower fee rate
+        assert tx_to_be_evicted_id not in node.getrawmempool()
 
-        self.log.info('Check that mempoolminfee is larger than minrelytxfee')
-        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_greater_than(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        self.log.info("Check that mempoolminfee is larger than minrelytxfee")
+        assert_equal(node.getmempoolinfo()["minrelaytxfee"], Decimal("0.00001000"))
+        assert_greater_than(
+            node.getmempoolinfo()["mempoolminfee"], Decimal("0.00001000")
+        )
 
-        self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        # We deliberately create a tx with a fee less that the minimum mempool fee to assert that it does not get added to the mempool
-        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee,mempool_valid=False)
+        # Deliberately tries to create a tx with a fee less that the minimum mempool fee to assert that it does not get added to the mempool
+        self.log.info("Create a mempool tx that will not pass mempoolminfee")
+        assert_raises_rpc_error(
+            -26,
+            "mempool min fee not met",
+            miniwallet.send_self_transfer,
+            from_node=node,
+            fee_rate=relayfee,
+            mempool_valid=False,
+        )
 
-    def create_large_transactions(self, node, array_of_large_tx, miniwallet, no_of_tx_ids, fee_rate):
-    # This helper function is used to create large transactions by splicing in "txouts"
-        large_txids = []
-        for _ in range(no_of_tx_ids):
-        # Loop that gives us a list of size num of large transaction IDs 
-            tx = miniwallet.create_self_transfer(from_node=node, fee_rate=fee_rate)
-            # We create a self transfer here and get the tx details
-            hex=tx['hex']
-            tx_instance = from_hex(CTransaction(), hex)
-            # We convert it into a CTransaction() instance
-            for txout in array_of_large_tx:
-                tx_instance.vout.append(txout)
-            # We append the tx outs that we received from the gen_return_txouts() to our tx instance to increase the tx size
-            tx_hex = tx_instance.serialize().hex()
-            miniwallet.sendrawtransaction(from_node=self.nodes[0], tx_hex=tx_hex)
-            # We now serialisze it and send the tx to the nodes
 
-            large_txids.append(tx['txid'])
-            # We now append this tx ID to our array of large tx IDs
-        return large_txids
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     MempoolLimitTest().main()

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -7,7 +7,10 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, gen_return_txouts
+from test_framework.wallet import MiniWallet
+from test_framework.messages import CTransaction, from_hex
+import pdb
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -20,55 +23,50 @@ class MempoolLimitTest(BitcoinTestFramework):
         ]]
         self.supports_cli = False
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         txouts = gen_return_txouts()
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
+        node = self.nodes[0]
+        miniwallet = MiniWallet(node)
+        relayfee = node.getnetworkinfo()['relayfee']
 
         self.log.info('Check that mempoolminfee is minrelytxfee')
-        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
-        txids = []
-        utxos = create_confirmed_utxos(relayfee, self.nodes[0], 91)
+        txids=[]
+        miniwallet.generate(92)
+        node.generate(100)
 
         self.log.info('Create a mempool tx that will be evicted')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        self.nodes[0].settxfee(relayfee) # specifically fund this tx with low fee
-        txF = self.nodes[0].fundrawtransaction(tx)
-        self.nodes[0].settxfee(0) # return to automatic fee selection
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        txid = self.nodes[0].sendrawtransaction(txFS['hex'])
+        txid = miniwallet.send_self_transfer(fee_rate = relayfee, from_node = node)['txid']
 
-        relayfee = self.nodes[0].getnetworkinfo()['relayfee']
-        base_fee = relayfee*100
+        mempool_min_fee = node.getmempoolinfo()['mempoolminfee']
+        base_fee = relayfee*1000
         for i in range (3):
             txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+            txids[i] = self.create_large_transactions(node, txouts, miniwallet, 30, (i+1)*base_fee)
 
         self.log.info('The tx should be evicted by now')
-        assert txid not in self.nodes[0].getrawmempool()
-        txdata = self.nodes[0].gettransaction(txid)
-        assert txdata['confirmations'] ==  0  #confirmation should still be 0
+        assert_greater_than(len([txid for batch in txids for txid in batch]), len(node.getrawmempool()))
+        assert txid not in node.getrawmempool() # check txid in the raw mempool
 
         self.log.info('Check that mempoolminfee is larger than minrelytxfee')
-        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
-        assert_greater_than(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+        assert_equal(node.getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_greater_than(node.getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
         self.log.info('Create a mempool tx that will not pass mempoolminfee')
-        us0 = utxos.pop()
-        inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
-        outputs = {self.nodes[0].getnewaddress() : 0.0001}
-        tx = self.nodes[0].createrawtransaction(inputs, outputs)
-        # specifically fund this tx with a fee < mempoolminfee, >= than minrelaytxfee
-        txF = self.nodes[0].fundrawtransaction(tx, {'feeRate': relayfee})
-        txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        assert_raises_rpc_error(-26, "mempool min fee not met", self.nodes[0].sendrawtransaction, txFS['hex'])
+        assert_raises_rpc_error(-26, "mempool min fee not met", miniwallet.send_self_transfer, from_node=node, fee_rate=relayfee)
+
+    def create_large_transactions(self, node, txouts, miniwallet, num, fee):
+        large_txids = []
+        for j in range(num):
+            hex = miniwallet.send_self_transfer(from_node=node, fee_rate=fee)['hex']
+            tx = from_hex(CTransaction(), hex)
+            tx.vout.extend(txouts)
+            tx_hex = tx.serialize().hex()
+            txid = node.sendrawtransaction(tx_hex, 0)
+            large_txids.append(txid)
+        return large_txids
 
 if __name__ == '__main__':
     MempoolLimitTest().main()

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -177,4 +177,3 @@ class MiniWallet:
     def sendrawtransaction(self, *, from_node, tx_hex):
         from_node.sendrawtransaction(tx_hex)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
-        

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -177,3 +177,6 @@ class MiniWallet:
     def sendrawtransaction(self, *, from_node, tx_hex):
         from_node.sendrawtransaction(tx_hex)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
+
+    def get_all_utxos(self):
+        return self._utxos

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -177,6 +177,4 @@ class MiniWallet:
     def sendrawtransaction(self, *, from_node, tx_hex):
         from_node.sendrawtransaction(tx_hex)
         self.scan_tx(from_node.decoderawtransaction(tx_hex))
-
-    def get_all_utxos(self):
-        return self._utxos
+        


### PR DESCRIPTION
This is a PR proposed in #20078

This PR enables running another non-wallet functional test even when the wallet is disabled thanks to the MiniWallet, i.e. it can be run even when bitcoin-core is compiled with --disable-wallet feature.

I have also created an extra method, `create_large_transactions()` to create large transactions for miniWallet.

Efforts for this feature started [here](https://github.com/bitcoin/bitcoin/pull/20874/files) but were not continued for a while now hence I picked it up.

To test this PR locally, compile and build bitcoin-core without the wallet and run:
```
test/functional/mempool_limit.py
```

PS: I will send it as a single commit and the only file changed will be the `mempool_limit.py`